### PR TITLE
docs: fix typos in markdown files

### DIFF
--- a/java-chassis-samples/jaxrs-sample/README.md
+++ b/java-chassis-samples/jaxrs-sample/README.md
@@ -13,7 +13,7 @@ ServiceComb supports developers in developing services in JAX-RS mode by using J
 
 ### Consumer Service
 
-To consume a provider-service, only need to decalare a member of a service API type and add the `RpcReference` annotation for the member, the microservice that depends on the declaration and the `schemaID` just like pojo consumer sample.
+To consume a provider-service, only need to declare a member of a service API type and add the `RpcReference` annotation for the member, the microservice that depends on the declaration and the `schemaID` just like pojo consumer sample.
 
 ## Precondition
 see [Precondition](../../README.md)

--- a/java-chassis-samples/metrics-extend-healthcheck/README.md
+++ b/java-chassis-samples/metrics-extend-healthcheck/README.md
@@ -1,6 +1,6 @@
 # Extend Metrics Health Checker Sample
 ## What is Health Checker
-Because micro-services is desgin by SRP(Single Responsibility Principle),one micro-service always depend on many components such as middle-ware like queue,database etc and other micro-services,so if one micro-service report failure,we want fast know what is the cause and more details to help us solve the problem.
+Because micro-services is designed by SRP(Single Responsibility Principle),one micro-service always depend on many components such as middle-ware like queue,database etc and other micro-services,so if one micro-service report failure,we want fast know what is the cause and more details to help us solve the problem.
 
 Health check mechanism can let user write some logic to check components of micro-service dependent and return check result.
 

--- a/porter_lightweight/README.md
+++ b/porter_lightweight/README.md
@@ -77,7 +77,7 @@ java $JAVA_OPT -Ddb.url="jdbc:mysql://localhost/porter_user_db?useSSL=false" -Dd
 java $JAVA_OPT -jar porter-file-service-0.0.1-SNAPSHOT.jar >/dev/null 2>&1 &
 ```
 
-* 启动gateway-serivce:
+* 启动gateway-service:
 
 gateway-service包含了静态页面文件，在resources/ui目录。首先需要将页面文件拷贝到WEB主目录（相对路径，当前运行目录），比如: webapp，然后将ui目录整体拷贝到webapp/ui目录(注意：porter_lightweight/gateway-service/src/main/resources/microservice.yaml中的相关配置
 gateway:webroot: /code/servicecomb-samples/porter_lightweight/gateway-service/src/main/resources是自己本地代码的位置)。启动：

--- a/porter_springboot/README.md
+++ b/porter_springboot/README.md
@@ -77,7 +77,7 @@ java $JAVA_OPT -Ddb.url="jdbc:mysql://localhost/porter_user_db?useSSL=false" -Dd
 java $JAVA_OPT -jar porter-file-service-2.0-SNAPSHOT.jar >/dev/null 2>&1 &
 ```
 
-* 启动 gateway-serivce:
+* 启动 gateway-service:
 
 ```
 java $JAVA_OPT -jar porter-gateway-service-2.0-SNAPSHOT.jar >/dev/null 2>&1 &


### PR DESCRIPTION
I have fixed some typos in markdown files. Following are the fixed typos:
1. decalare -> declare
2. desgin -> designed
3. serivce -> service

I kindly request the repository maintainers to review and merge it. Thanks! :heart: